### PR TITLE
listxattr: Test errno != 0 before returning error

### DIFF
--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -18,7 +18,10 @@ func getxattr(path string, name string, value *byte, size int, pos int, options 
 
 func listxattr(path string, namebuf *byte, size int, options int) (int, error) {
 	r0, _, e1 := syscall.Syscall6(syscall.SYS_LISTXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), uintptr(unsafe.Pointer(namebuf)), uintptr(size), uintptr(options), 0, 0)
-	return int(r0), e1
+	if e1 != syscall.Errno(0) {
+		return int(r0), e1
+	}
+	return int(r0), nil
 }
 
 func setxattr(path string, name string, value *byte, size int, pos int, options int) error {

--- a/xattr_darwin.go
+++ b/xattr_darwin.go
@@ -26,6 +26,10 @@ func Listxattr(path string) ([]string, error) {
 	if err != nil {
 		return nil, &XAttrError{"listxattr", path, "", err}
 	}
+	if size == 0 {
+		return []string{}, nil
+	}
+
 	buf := make([]byte, size)
 	// Read into buffer of that size.
 	read, err := listxattr(path, &buf[0], size, 0)

--- a/xattr_test.go
+++ b/xattr_test.go
@@ -23,6 +23,22 @@ func Test_setxattr(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	list, err := Listxattr(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, name := range list {
+		if name == UserPrefix+"test" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("Listxattr did not return test attribute")
+	}
+
 	var data []byte
 	data, err = Getxattr(tmp.Name(), UserPrefix+"test")
 	if err != nil {
@@ -32,5 +48,10 @@ func Test_setxattr(t *testing.T) {
 	t.Log(value)
 	if "test-attr-value" != value {
 		t.Fail()
+	}
+
+	err = Removexattr(tmp.Name(), UserPrefix+"test")
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Hi, and thanks for providing this library! I'm using it for [restic](https://github.com/restic/restic), a secure, fast and deduplicated backup program.

We've recently discovered that under some circumstances, `Listxattr()` on Darwin seems to return an error with `errno` set to zero, e.g. here: https://travis-ci.org/restic/restic/jobs/202245770#L138

Looking at the source code, the other functions check for `errno != 0` and only then return an error: https://github.com/pkg/xattr/blob/master/syscall_darwin.go#L13
It seems this check is missing for `listxattr()`.

A demo program can be found here: https://gist.github.com/11156f3d7cc5af48b9a5b654e872c2dc

For a file `foo` without extended attributes this prints the following:
```
$ go run main.go foo
[] &xattr.XAttrError{Op:"listxattr", Path:"foo", Name:"", Err:0x0}
```

You can see that an error is returned.
