### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+sudo: false
+
+go:
+  - 1.7.5
+  - 1.8
+  - tip
+
+os:
+  - linux
+  - osx
+
+install:
+  - go version
+  - export GOBIN="$GOPATH/bin"
+  - export PATH="$PATH:$GOBIN"
+  - go get golang.org/x/tools/cmd/goimports
+
+script:
+  - go test
+  - diff <(GOPATH="$PWD:$PWD/vendor" goimports -d ./src) <(printf "")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![GoDoc](https://godoc.org/github.com/pkg/xattr?status.svg)](http://godoc.org/github.com/pkg/xattr)
+[![Build Status](https://travis-ci.org/pkg/xattr.svg?branch=master)](https://travis-ci.org/pkg/xattr)
+
 xattr
 =====
 Extended attribute support for Go (linux + darwin + freebsd).


### PR DESCRIPTION
This commit adds a Travis config, I've verified that it works with my fork: https://travis-ci.org/fd0/xattr/builds/202926312
It runs the tests on Linux and Darwin for both Go 1.8 and 1.7.5. In addition, it uses `goimports` to check if the code is properly formatted.

It also adds badges for the README.md.

Please enable Travis for this repo before merging this PR.