### PR TITLE
Travis: fix directory for goimports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 
 script:
   - go test
-  - diff <(GOPATH="$PWD:$PWD/vendor" goimports -d ./src) <(printf "")
+  - diff <(GOPATH="$PWD:$PWD/vendor" goimports -d .) <(printf "")


### PR DESCRIPTION
This PR corrects the call to `goimports`, which is currently called with a non-existing directory:
```
The command "go test" exited with 0.
0.01s$ diff <(GOPATH="$PWD:$PWD/vendor" goimports -d ./src) <(printf "")
stat ./src: no such file or directory
```