### PR TITLE
Added passing of the flags parameter to the lower-level syscall

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Extended attribute support for Go (linux + darwin + freebsd).
 
 "Extended attributes are name:value pairs associated permanently with files and directories, similar to the environment strings associated with a process. An attribute may be defined or undefined. If it is defined, its value may be empty or non-empty." [See more...](https://en.wikipedia.org/wiki/Extended_file_attributes)
 
+`SetWithFlags` allows to additionally pass system flags to be forwarded to the underlying calls, FreeBSD does not support this and the parameter will be ignored.
 
 ### Example
 ```go
@@ -29,6 +30,11 @@ Extended attribute support for Go (linux + darwin + freebsd).
   }
 
   if err = xattr.Remove(path, prefix+"test"); err != nil {
+  	log.Fatal(err)
+  }
+
+  // One can also specify the flags parameter to be passed to the OS.
+  if err := xattr.SetWithFlags(path, prefix+"test", []byte("test-attr-value"), xattr.XATTR_CREATE); err != nil {
   	log.Fatal(err)
   }
 ```

--- a/xattr.go
+++ b/xattr.go
@@ -39,8 +39,8 @@ func Get(path, name string) ([]byte, error) {
 }
 
 // Set associates name and data together as an attribute of path.
-func Set(path, name string, data []byte) error {
-	if err := setxattr(path, name, data, 0); err != nil {
+func Set(path, name string, data []byte, flags int) error {
+	if err := setxattr(path, name, data, flags); err != nil {
 		return &Error{"xattr.Set", path, name, err}
 	}
 	return nil

--- a/xattr.go
+++ b/xattr.go
@@ -39,9 +39,14 @@ func Get(path, name string) ([]byte, error) {
 }
 
 // Set associates name and data together as an attribute of path.
-func Set(path, name string, data []byte, flags int) error {
+func Set(path, name string, data []byte) error {
+	return SetWithFlags(path, name, data, 0)
+}
+
+// SetWithFlags associates name and data together as an attribute of path. Forwards the flags parameter to the syscall layer.
+func SetWithFlags(path, name string, data []byte, flags int) error {
 	if err := setxattr(path, name, data, flags); err != nil {
-		return &Error{"xattr.Set", path, name, err}
+		return &Error{"xattr.SetWithFlags", path, name, err}
 	}
 	return nil
 }

--- a/xattr_darwin.go
+++ b/xattr_darwin.go
@@ -7,6 +7,16 @@ import (
 	"unsafe"
 )
 
+// See https://opensource.apple.com/source/xnu/xnu-1504.15.3/bsd/sys/xattr.h.auto.html
+const (
+	XATTR_NOFOLLOW        = 0x0001
+	XATTR_CREATE          = 0x0002
+	XATTR_REPLACE         = 0x0004
+	XATTR_NOSECURITY      = 0x0008
+	XATTR_NODEFAULT       = 0x0010
+	XATTR_SHOWCOMPRESSION = 0x0020
+)
+
 func getxattr(path string, name string, data []byte) (int, error) {
 	value, size := bytePtrFromSlice(data)
 	/*
@@ -40,7 +50,7 @@ func setxattr(path string, name string, data []byte, flags int) error {
 		);
 	*/
 	_, _, err := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))),
-		uintptr(unsafe.Pointer(syscall.StringBytePtr(name))), uintptr(unsafe.Pointer(value)), uintptr(size), 0, 0)
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(name))), uintptr(unsafe.Pointer(value)), uintptr(size), 0, uintptr(flags))
 	if err != syscall.Errno(0) {
 		return err
 	}

--- a/xattr_flags_test.go
+++ b/xattr_flags_test.go
@@ -1,0 +1,23 @@
+// +build linux darwin
+
+package xattr
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFlags(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+
+	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_CREATE)
+	checkIfError(t, err)
+
+	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_REPLACE)
+	checkIfError(t, err)
+}

--- a/xattr_linux.go
+++ b/xattr_linux.go
@@ -6,6 +6,11 @@ import (
 	"syscall"
 )
 
+const (
+	XATTR_CREATE  = 0x0001
+	XATTR_REPLACE = 0x0002
+)
+
 func getxattr(path string, name string, data []byte) (int, error) {
 	return syscall.Getxattr(path, name, data)
 }

--- a/xattr_test.go
+++ b/xattr_test.go
@@ -18,7 +18,7 @@ func Test(t *testing.T) {
 	}
 	defer os.Remove(tmp.Name())
 
-	err = Set(tmp.Name(), UserPrefix+"test", []byte("test-attr-value"))
+	err = Set(tmp.Name(), UserPrefix+"test", []byte("test-attr-value"), 0)
 	checkIfError(t, err)
 
 	list, err := List(tmp.Name())
@@ -56,7 +56,7 @@ func TestNoData(t *testing.T) {
 	}
 	defer os.Remove(tmp.Name())
 
-	err = Set(tmp.Name(), UserPrefix+"test", []byte{})
+	err = Set(tmp.Name(), UserPrefix+"test", []byte{}, 0)
 	checkIfError(t, err)
 
 	list, err := List(tmp.Name())

--- a/xattr_test.go
+++ b/xattr_test.go
@@ -18,7 +18,7 @@ func Test(t *testing.T) {
 	}
 	defer os.Remove(tmp.Name())
 
-	err = Set(tmp.Name(), UserPrefix+"test", []byte("test-attr-value"), 0)
+	err = Set(tmp.Name(), UserPrefix+"test", []byte("test-attr-value"))
 	checkIfError(t, err)
 
 	list, err := List(tmp.Name())
@@ -56,7 +56,7 @@ func TestNoData(t *testing.T) {
 	}
 	defer os.Remove(tmp.Name())
 
-	err = Set(tmp.Name(), UserPrefix+"test", []byte{}, 0)
+	err = Set(tmp.Name(), UserPrefix+"test", []byte{})
 	checkIfError(t, err)
 
 	list, err := List(tmp.Name())


### PR DESCRIPTION
This allows the client code to specify the `flags` parameter, that was previously zeroed.