### PR TITLE
Add more testcases for SetWithFlags

### DIFF
--- a/xattr_flags_test.go
+++ b/xattr_flags_test.go
@@ -15,9 +15,24 @@ func TestFlags(t *testing.T) {
 	}
 	defer os.Remove(tmp.Name())
 
-	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_CREATE)
+	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), 0)
 	checkIfError(t, err)
+
+	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_CREATE)
+	if err == nil {
+		t.Fatalf("XATTR_CREATE should have failed because the xattr already exists")
+	}
+	t.Log(err)
 
 	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_REPLACE)
 	checkIfError(t, err)
+
+	err = Remove(tmp.Name(), UserPrefix+"flags-test")
+	checkIfError(t, err)
+
+	err = SetWithFlags(tmp.Name(), UserPrefix+"flags-test", []byte("flags-test-attr-value"), XATTR_REPLACE)
+	if err == nil {
+		t.Fatalf("XATTR_REPLACE should have failed because there is nothing to replace")
+	}
+	t.Log(err)
 }


### PR DESCRIPTION
Check that XATTR_CREATE and XATTR_REPLACE fail
when they should (they do, everything seems to work fine).

Tested on Linux and MacOS High Sierra.