### PR TITLE
Support "F" variants of operations (on file descriptors)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pkg/xattr
 
-require golang.org/x/sys v0.0.0-20180525142821-c11f84a56e43
+require golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51

--- a/xattr_darwin.go
+++ b/xattr_darwin.go
@@ -3,6 +3,7 @@
 package xattr
 
 import (
+	"os"
 	"syscall"
 	"unsafe"
 
@@ -48,12 +49,20 @@ func lgetxattr(path string, name string, data []byte) (int, error) {
 	return int(r0), nil
 }
 
+func fgetxattr(f *os.File, name string, data []byte) (int, error) {
+	return getxattr(f.Name(), name, data)
+}
+
 func setxattr(path string, name string, data []byte, flags int) error {
 	return unix.Setxattr(path, name, data, flags)
 }
 
 func lsetxattr(path string, name string, data []byte, flags int) error {
 	return unix.Setxattr(path, name, data, flags|XATTR_NOFOLLOW)
+}
+
+func fsetxattr(f *os.File, name string, data []byte, flags int) error {
+	return setxattr(f.Name(), name, data, flags)
 }
 
 func removexattr(path string, name string) error {
@@ -76,6 +85,10 @@ func lremovexattr(path string, name string) error {
 	return nil
 }
 
+func fremovexattr(f *os.File, name string) error {
+	return removexattr(f.Name(), name)
+}
+
 func listxattr(path string, data []byte) (int, error) {
 	return unix.Listxattr(path, data)
 }
@@ -96,6 +109,10 @@ func llistxattr(path string, data []byte) (int, error) {
 		return int(r0), err
 	}
 	return int(r0), nil
+}
+
+func flistxattr(f *os.File, data []byte) (int, error) {
+	return listxattr(f.Name(), data)
 }
 
 // stringsFromByteSlice converts a sequence of attributes to a []string.

--- a/xattr_freebsd.go
+++ b/xattr_freebsd.go
@@ -3,6 +3,7 @@
 package xattr
 
 import (
+	"os"
 	"syscall"
 	"unsafe"
 )
@@ -22,6 +23,10 @@ func getxattr(path string, name string, data []byte) (int, error) {
 
 func lgetxattr(path string, name string, data []byte) (int, error) {
 	return sysGet(syscall.SYS_EXTATTR_GET_LINK, path, name, data)
+}
+
+func fgetxattr(f *os.File, name string, data []byte) (int, error) {
+	return getxattr(f.Name(), name, data)
 }
 
 // sysGet is called by getxattr and lgetxattr with the appropriate syscall
@@ -59,6 +64,10 @@ func setxattr(path string, name string, data []byte, flags int) error {
 
 func lsetxattr(path string, name string, data []byte, flags int) error {
 	return sysSet(syscall.SYS_EXTATTR_SET_LINK, path, name, data)
+}
+
+func fsetxattr(f *os.File, name string, data []byte, flags int) error {
+	return setxattr(f.Name(), name, data, flags)
 }
 
 // sysSet is called by setxattr and lsetxattr with the appropriate syscall
@@ -103,6 +112,10 @@ func lremovexattr(path string, name string) error {
 	return sysRemove(syscall.SYS_EXTATTR_DELETE_LINK, path, name)
 }
 
+func fremovexattr(f *os.File, name string) error {
+	return removexattr(f.Name(), name)
+}
+
 // sysSet is called by removexattr and lremovexattr with the appropriate syscall
 // number. This works because syscalls have the same signature and return
 // values.
@@ -135,6 +148,10 @@ func listxattr(path string, data []byte) (int, error) {
 
 func llistxattr(path string, data []byte) (int, error) {
 	return sysList(syscall.SYS_EXTATTR_LIST_LINK, path, data)
+}
+
+func flistxattr(f *os.File, data []byte) (int, error) {
+	return listxattr(f.Name(), data)
 }
 
 // sysSet is called by listxattr and llistxattr with the appropriate syscall

--- a/xattr_linux.go
+++ b/xattr_linux.go
@@ -3,6 +3,7 @@
 package xattr
 
 import (
+	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -26,12 +27,20 @@ func lgetxattr(path string, name string, data []byte) (int, error) {
 	return unix.Lgetxattr(path, name, data)
 }
 
+func fgetxattr(f *os.File, name string, data []byte) (int, error) {
+	return unix.Fgetxattr(int(f.Fd()), name, data)
+}
+
 func setxattr(path string, name string, data []byte, flags int) error {
 	return unix.Setxattr(path, name, data, flags)
 }
 
 func lsetxattr(path string, name string, data []byte, flags int) error {
 	return unix.Lsetxattr(path, name, data, flags)
+}
+
+func fsetxattr(f *os.File, name string, data []byte, flags int) error {
+	return unix.Fsetxattr(int(f.Fd()), name, data, flags)
 }
 
 func removexattr(path string, name string) error {
@@ -42,12 +51,20 @@ func lremovexattr(path string, name string) error {
 	return unix.Lremovexattr(path, name)
 }
 
+func fremovexattr(f *os.File, name string) error {
+	return unix.Fremovexattr(int(f.Fd()), name)
+}
+
 func listxattr(path string, data []byte) (int, error) {
 	return unix.Listxattr(path, data)
 }
 
 func llistxattr(path string, data []byte) (int, error) {
 	return unix.Llistxattr(path, data)
+}
+
+func flistxattr(f *os.File, data []byte) (int, error) {
+	return unix.Flistxattr(int(f.Fd()), data)
 }
 
 // stringsFromByteSlice converts a sequence of attributes to a []string.

--- a/xattr_test.go
+++ b/xattr_test.go
@@ -42,10 +42,20 @@ func TestRegularFile(t *testing.T) {
 			remove:       LRemove,
 			list:         LList,
 		},
+		{
+			familyName:   "FGet and friends",
+			get:          wrapFGet,
+			set:          wrapFSet,
+			setWithFlags: wrapFSetWithFlags,
+			remove:       wrapFRemove,
+			list:         wrapFList,
+		},
 	}
 	for _, ff := range families {
-		t.Logf("Testing %q on a regular file", ff.familyName)
-		testRegularFile(t, ff)
+		t.Run(ff.familyName, func(t *testing.T) {
+			t.Logf("Testing %q on a regular file", ff.familyName)
+			testRegularFile(t, ff)
+		})
 	}
 }
 
@@ -272,4 +282,51 @@ func unpackSysErr(err error) syscall.Errno {
 		log.Panicf("cannot unpack err=%#v", err)
 	}
 	return err2.Err.(syscall.Errno)
+}
+
+// wrappers to adapt "F" variants to the test
+
+func wrapFGet(path, name string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return FGet(f, name)
+}
+
+func wrapFSet(path, name string, data []byte) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return FSet(f, name, data)
+}
+
+func wrapFSetWithFlags(path, name string, data []byte, flags int) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return FSetWithFlags(f, name, data, flags)
+}
+
+func wrapFRemove(path, name string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return FRemove(f, name)
+}
+
+func wrapFList(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return FList(f)
 }


### PR DESCRIPTION
In unix, there is a possibility to create files without a path, for example by using `O_TMPFILE` flag in [open(2)](http://man7.org/linux/man-pages/man2/open.2.html).

This change adds a set of "F" variants to all functions that accepts a file descriptor instead of a path.

Only implemented for Linux, all other platforms use `Name()` call on a file to get its path.