### PR TITLE
Fix windows and unsupported platform builds with dummy values

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -9,6 +9,9 @@ GOOS=darwin  go build
 echo "Building for FreeBSD..."
 GOOS=freebsd go build
 
+echo "Building for Windows...(dummy)"
+GOOS=windows go build
+
 echo "Running tests..."
 go vet
 go test -v -race -coverprofile=coverage.txt -covermode=atomic

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 os:
   - linux
   - osx
+  - windows
 
 before_install:
   - go version
@@ -18,7 +19,8 @@ install:
 
 script:
   - ./.travis.sh
-  - diff <(goimports -d .) <(printf "")
+  # goimports on windows gives false positives
+  - if [[ "${TRAVIS_OS_NAME}" != "windows" ]]; then diff <(goimports -d .) <(printf ""); fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/xattr_unsupported.go
+++ b/xattr_unsupported.go
@@ -1,0 +1,60 @@
+// +build !linux,!freebsd,!netbsd,!darwin
+
+package xattr
+
+import (
+	"os"
+)
+
+func getxattr(path string, name string, data []byte) (int, error) {
+	return 0, nil
+}
+
+func lgetxattr(path string, name string, data []byte) (int, error) {
+	return 0, nil
+}
+
+func fgetxattr(f *os.File, name string, data []byte) (int, error) {
+	return 0, nil
+}
+
+func setxattr(path string, name string, data []byte, flags int) error {
+	return nil
+}
+
+func lsetxattr(path string, name string, data []byte, flags int) error {
+	return nil
+}
+
+func fsetxattr(f *os.File, name string, data []byte, flags int) error {
+	return nil
+}
+
+func removexattr(path string, name string) error {
+	return nil
+}
+
+func lremovexattr(path string, name string) error {
+	return nil
+}
+
+func fremovexattr(f *os.File, name string) error {
+	return nil
+}
+
+func listxattr(path string, data []byte) (int, error) {
+	return 0, nil
+}
+
+func llistxattr(path string, data []byte) (int, error) {
+	return 0, nil
+}
+
+func flistxattr(f *os.File, data []byte) (int, error) {
+	return 0, nil
+}
+
+// dummy
+func stringsFromByteSlice(buf []byte) (result []string) {
+	return []string{}
+}


### PR DESCRIPTION
To fix https://travis-ci.org/minio/mc/jobs/511289483 

```
# github.com/pkg/xattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:40:10: undefined: getxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:47:10: undefined: lgetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:54:10: undefined: fgetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:106:12: undefined: setxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:115:12: undefined: lsetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:123:12: undefined: fsetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:132:12: undefined: setxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:141:12: undefined: lsetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:149:12: undefined: fsetxattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:157:12: undefined: removexattr
..\..\..\..\pkg\mod\github.com\pkg\xattr@v0.4.0\xattr.go:157:12: too many errors
The command "go build --ldflags="$(go run buildscripts/gen-ldflags.go)" -o %GOPATHin\mc.exe" exited with 2.
```