### PR TITLE
Added constant for whether xattrs are supported by the current platform

### DIFF
--- a/xattr_bsd.go
+++ b/xattr_bsd.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	// XATTR_SUPPORTED will be true if the current platform is supported
+	XATTR_SUPPORTED = true
+
 	EXTATTR_NAMESPACE_USER = 1
 
 	// ENOATTR is not exported by the syscall package on Linux, because it is

--- a/xattr_darwin.go
+++ b/xattr_darwin.go
@@ -11,6 +11,9 @@ import (
 
 // See https://opensource.apple.com/source/xnu/xnu-1504.15.3/bsd/sys/xattr.h.auto.html
 const (
+	// XATTR_SUPPORTED will be true if the current platform is supported
+	XATTR_SUPPORTED = true
+
 	XATTR_NOFOLLOW        = 0x0001
 	XATTR_CREATE          = 0x0002
 	XATTR_REPLACE         = 0x0004

--- a/xattr_linux.go
+++ b/xattr_linux.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	// XATTR_SUPPORTED will be true if the current platform is supported
+	XATTR_SUPPORTED = true
+
 	XATTR_CREATE  = unix.XATTR_CREATE
 	XATTR_REPLACE = unix.XATTR_REPLACE
 

--- a/xattr_unsupported.go
+++ b/xattr_unsupported.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// XATTR_SUPPORTED will be true if the current platform is supported
+const XATTR_SUPPORTED = false
+
 func getxattr(path string, name string, data []byte) (int, error) {
 	return 0, nil
 }


### PR DESCRIPTION
This will be useful for [us](https://github.com/thought-machine/please) so we can determine whether we need to fall back to a file based approach when they're not supported. 