### PR TITLE
Restore Go 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: go
 sudo: false
 
 go:
-  - "1.15.x"
+  - "1.11.x" # Debian 10 "Buster"
+  - "1.12.x" # Ubuntu 19.10
+  - "1.13.x" # Debian 11 "Bullseye"
   - "1.14.x"
+  - "1.15.x"
+  - stable   # Latest Go release
 
 os:
   - linux

--- a/xattr_linux.go
+++ b/xattr_linux.go
@@ -3,7 +3,6 @@
 package xattr
 
 import (
-	"errors"
 	"os"
 	"syscall"
 
@@ -31,7 +30,7 @@ const (
 func ignoringEINTR(fn func() error) (err error) {
 	for {
 		err = fn()
-		if !errors.Is(err, unix.EINTR) {
+		if err != unix.EINTR {
 			break
 		}
 	}


### PR DESCRIPTION
"errors.Is()" need Go 1.13 and higher. We can do with
a plain "==" here and keep Go 1.11 support without a problem.

Also add Go 1.11+ back to Travis.

See the discussion at
https://github.com/pkg/xattr/commit/994316708194a4ca6198b54c879dc5881ca59c71#r44193396
for details.