### PR TITLE
Check for EINTR with != on Linux

### DIFF
--- a/xattr_linux.go
+++ b/xattr_linux.go
@@ -3,7 +3,6 @@
 package xattr
 
 import (
-	"errors"
 	"os"
 	"syscall"
 
@@ -31,7 +30,7 @@ const (
 func ignoringEINTR(fn func() error) (err error) {
 	for {
 		err = fn()
-		if !errors.Is(err, unix.EINTR) {
+		if err != unix.EINTR {
 			break
 		}
 	}


### PR DESCRIPTION
This was already suggested in #52 and #53 with the aim of restoring Go 1.11 compatibility. That may not work, but omitting errors.Is does allow Go 1.16 to inline ignoringEINTR at every call site.