### PR TITLE
add alias to unsupported

### DIFF
--- a/xattr_unsupported.go
+++ b/xattr_unsupported.go
@@ -1,9 +1,16 @@
+//go:build !linux && !freebsd && !netbsd && !darwin && !solaris
 // +build !linux,!freebsd,!netbsd,!darwin,!solaris
 
 package xattr
 
 import (
 	"os"
+	"syscall"
+)
+
+const (
+	// We need to use the default for non supported operating systems
+	ENOATTR = syscall.ENODATA
 )
 
 // XATTR_SUPPORTED will be true if the current platform is supported


### PR DESCRIPTION
# Description

If we want to use the `xattr.ENOATTR` safely in projects, we also need to define it for the unsuported Operating systems to make the compiler happy.