### PR TITLE
Make xattr.Error implement Unwrap

### DIFF
--- a/xattr.go
+++ b/xattr.go
@@ -29,6 +29,8 @@ type Error struct {
 	Err  error
 }
 
+func (e *Error) Unwrap() error { return e.Err }
+
 func (e *Error) Error() (errstr string) {
 	if e.Op != "" {
 		errstr += e.Op


### PR DESCRIPTION
This makes `xattr.Error` implement the `Unwrap` interface. It allows consumers to inspect the errors more efficiently like:

```go
_, err := xattr.Get("file", "attribute")
if err != nil {
    if errors.Is(err, fs.ErrNotFound) {
        //Do something
    }
}
```
