### PR TITLE
syscall.ENODATA is not defined on unsupported OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         GOOS=freebsd go build
         GOOS=windows go build
+        GOOS=openbsd go build
         go build -v .
 
     - name: Test

--- a/xattr_unsupported.go
+++ b/xattr_unsupported.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// We need to use the default for non supported operating systems
-	ENOATTR = syscall.ENODATA
+	ENOATTR = syscall.Errno(0x59)
 )
 
 // XATTR_SUPPORTED will be true if the current platform is supported


### PR DESCRIPTION
ENODATA may not be defined use a dummy value from netbsd errno