### PR TITLE
Fix FIFO handling on Solaris

### DIFF
--- a/xattr_solaris.go
+++ b/xattr_solaris.go
@@ -24,7 +24,7 @@ const (
 )
 
 func getxattr(path string, name string, data []byte) (int, error) {
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	f, err := os.OpenFile(path, os.O_RDONLY|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -50,7 +50,7 @@ func fgetxattr(f *os.File, name string, data []byte) (int, error) {
 }
 
 func setxattr(path string, name string, data []byte, flags int) error {
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	f, err := os.OpenFile(path, os.O_RDONLY|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func fremovexattr(f *os.File, name string) error {
 }
 
 func listxattr(path string, data []byte) (int, error) {
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	f, err := os.OpenFile(path, os.O_RDONLY|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -152,7 +152,7 @@ func flistxattr(f *os.File, data []byte) (int, error) {
 }
 
 // stringsFromByteSlice converts a sequence of attributes to a []string.
-// On Darwin and Linux, each entry is a NULL-terminated string.
+// We simulate Linux/Darwin, where each entry is a NULL-terminated string.
 func stringsFromByteSlice(buf []byte) (result []string) {
 	offset := 0
 	for index, b := range buf {

--- a/xattr_solaris.go
+++ b/xattr_solaris.go
@@ -87,7 +87,8 @@ func fsetxattr(f *os.File, name string, data []byte, flags int) error {
 }
 
 func removexattr(path string, name string) error {
-	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_XATTR, 0)
+	mode := unix.O_RDONLY | unix.O_XATTR | unix.O_NONBLOCK | unix.O_CLOEXEC
+	fd, err := unix.Open(path, mode, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On Solaris, files need to be opened to obtain or change their attributes. But opening a FIFO file causes the calling thread to block until the write end is opened. Files are now opened using O_NONBLOCK to prevent this from happening.

Should fix restic/restic#4003.

Also fix comment on stringsFromByteSlice.

This code compiles, but I've not been able to test it without access to a Solaris box. I'm hoping @andy-js, @gco, and/or @racingmars can review/test this.